### PR TITLE
Add indexes

### DIFF
--- a/android/src/main/java/com/patrickcremin/react/RNSyncModule.java
+++ b/android/src/main/java/com/patrickcremin/react/RNSyncModule.java
@@ -71,7 +71,7 @@ public class RNSyncModule extends ReactContextBaseJavaModule {
 
     private DatastoreManager manager;
     private Replicator replicator;
-    private URI uri;
+    private HashMap<String,URI> uris = new HashMap<>();
     private HashMap<String,Datastore> datastores = new HashMap<>();
     private HashMap<String,IndexManager> indexManagers = new HashMap<>();
 
@@ -99,10 +99,11 @@ public class RNSyncModule extends ReactContextBaseJavaModule {
     public void init(String databaseUrl, String databaseName, Callback callback) {
 
         try {
-            uri = new URI(databaseUrl);
+            URI uri = new URI(databaseUrl);
             Datastore ds = manager.openDatastore(databaseName);
             IndexManager im = new IndexManager(ds);
 
+            uris.put(databaseName, uri);
             datastores.put(databaseName, ds);
             indexManagers.put(databaseName, im);
         }
@@ -120,6 +121,7 @@ public class RNSyncModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void replicatePush(String databaseName, Callback callback) {
         Datastore ds = datastores.get(databaseName);
+        URI uri = uris.get(databaseName);
         if (ds==null) {
           callback.invoke("No datastore named " + databaseName);
           return;
@@ -159,6 +161,7 @@ public class RNSyncModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void replicatePull(String databaseName, Callback callback) {
         Datastore ds = datastores.get(databaseName);
+        URI uri = uris.get(databaseName);
         if (ds==null) {
           callback.invoke("No datastore named " + databaseName);
           return;

--- a/android/src/main/java/com/patrickcremin/react/RNSyncModule.java
+++ b/android/src/main/java/com/patrickcremin/react/RNSyncModule.java
@@ -330,6 +330,18 @@ public class RNSyncModule extends ReactContextBaseJavaModule {
             return;
         }
     }
+    
+    @ReactMethod
+    public void deleteDatastoreWithName(String databaseName, Callback callback) {
+      try {
+        manager.deleteDatastore(databaseName);
+        callback.invoke();
+      }
+      catch (Exception e) {
+        callback.invoke(e.getMessage());
+        return;
+      }
+    }
 
     @ReactMethod
     public void find(ReadableMap query, ReadableArray fields, String databaseName, Callback callback) {

--- a/index.js
+++ b/index.js
@@ -326,7 +326,17 @@ class RNSyncWrapper
     });
   }
 
-  // TODO: add deleteDatastore?
+  deleteDatastoreWithName (databaseName, callback) {
+    callback = callback || noop;
+
+    return new Promise((resolve, reject) => {
+      rnsyncModule.deleteDatastoreWithName(databaseName, (error) => {
+        callback(error);
+        if(error) reject(error);
+        else resolve();
+      });
+    });
+  }
 }
 
 export const rnsyncStorage = new RNSyncStorage();


### PR DESCRIPTION
- Add `deleteDatastoreWithName(databaseName, callback)`, this allow us to delete a datastore
- Fix Android issue when we `init()` more than one datastore.